### PR TITLE
Fix import inquirer

### DIFF
--- a/wodoo/tools.py
+++ b/wodoo/tools.py
@@ -5,6 +5,7 @@ import stat
 from contextlib import contextmanager
 import re
 import docker
+import inquirer
 
 try:
     import arrow


### PR DESCRIPTION
Import was deleted in this change:
![grafik](https://user-images.githubusercontent.com/34651555/187920247-26e5c183-fd84-4401-825c-b3545eeb98bf.png)

Error Message:

`Traceback (most recent call last):
  File "/var/lib/wodoo_env/bin/odoo", line 33, in <module>
    sys.exit(load_entry_point('wodoo==0.2.281', 'console_scripts', 'odoo')())
  File "/var/lib/wodoo_env/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/var/lib/wodoo_env/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/var/lib/wodoo_env/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/var/lib/wodoo_env/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/var/lib/wodoo_env/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/var/lib/wodoo_env/lib/python3.10/site-packages/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/var/lib/wodoo_env/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/var/lib/wodoo_env/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/var/lib/wodoo_env/lib/python3.10/site-packages/wodoo/lib_db.py", line 161, in reset_db
    _dropdb(config, conn)
  File "/var/lib/wodoo_env/lib/python3.10/site-packages/wodoo/tools.py", line 728, in _dropdb
    inquirer.Text(
NameError: name 'inquirer' is not defined`