### PR TITLE
IMP: hashing & module dependency tree

### DIFF
--- a/wodoo/lib_module.py
+++ b/wodoo/lib_module.py
@@ -1375,7 +1375,7 @@ def list_deps(ctx, config, module, no_cache):
 
     # get some hashes:
     paths = []
-    for path in ["odoo"]:
+    for path in ["odoo/odoo"]:
         paths.append(Path(path))
     for mod in data["modules"]:
         paths.append(Module.get_by_name(mod).path)

--- a/wodoo/module_tools.py
+++ b/wodoo/module_tools.py
@@ -755,6 +755,7 @@ class Modules(object):
             data[mod.name] = {}
             for dep in mod.manifest_dict.get("depends", []):
                 if dep == "base":
+                    data[mod.name][dep] = {}
                     continue
                 dep_mod = [x for x in self.modules.values() if x.name == dep]
                 try:


### PR DESCRIPTION
Now the base module is also listed as a dependency
The hashing will not use the hash of the whole odoo directory (which includes every module from odoo standard)
now it only using the hash from odoo/odoo directory, where the models.py fields.py tools, ... are located
otherwise if we patch module from odoo for example odoo/addons/delivery every hash will change not only the hashes of the modules which having a dependency on delivery