### PR TITLE
feat: MacOS improvements

### DIFF
--- a/wodoo/lib_composer.py
+++ b/wodoo/lib_composer.py
@@ -80,11 +80,15 @@ def config(ctx, config, service_name, full=True):
 
 
 def _get_arch():
-    arch = subprocess.check_output(["uname", "-m"], encoding="UTF-8").strip()
-    return {
+    mapping = {
         "x86_64": "amd64",
         "aarch64": "arm64",
-    }[arch]
+    }
+    arch = subprocess.check_output(["uname", "-m"], encoding="UTF-8").strip()
+    if arch in mapping:
+        return mapping[arch]
+    else:
+        return arch
 
 
 @composer.command(

--- a/wodoo/module_tools.py
+++ b/wodoo/module_tools.py
@@ -670,13 +670,8 @@ class Modules(object):
             Returns a list of full paths of all manifests
             """
             for path in reversed(get_odoo_addons_paths()):
-                mans = subprocess.check_output(
-                    ["find", ".", "-maxdepth", "2", "-name", manifest_file_names()],
-                    cwd=path,
-                    encoding="utf8",
-                ).splitlines()
+                mans = bashfind(path, name=manifest_file_names(), maxdepth=2)
                 for file in sorted(mans):
-                    file = path / file
                     modname = file.parent.name
                     if modname in modnames:
                         continue

--- a/wodoo/tools.py
+++ b/wodoo/tools.py
@@ -1474,15 +1474,9 @@ def _make_sure_module_is_installed(ctx, config, modulename, repo_url):
 
 
 def bashfind(path, name=None, wholename=None, type=None, maxdepth=None):
-    import platform
-
     cmd = [
-        "find",
+        "find", path
     ]
-    workdir = path
-    if platform.system() == "Darwin":
-        cmd.append(path)
-        workdir = None
     if type:
         cmd += ["-type", type]
     if maxdepth:
@@ -1493,7 +1487,7 @@ def bashfind(path, name=None, wholename=None, type=None, maxdepth=None):
         cmd += ["-name", name]
     if not Path(path).exists():
         return []
-    files = subprocess.check_output(cmd, cwd=workdir, encoding="utf8").splitlines()
+    files = subprocess.check_output(cmd, encoding="utf8").splitlines()
     return list(map(lambda x: Path(path) / x, files))
 
 

--- a/wodoo/tools.py
+++ b/wodoo/tools.py
@@ -1474,9 +1474,15 @@ def _make_sure_module_is_installed(ctx, config, modulename, repo_url):
 
 
 def bashfind(path, name=None, wholename=None, type=None):
+    import platform
+
     cmd = [
         "find",
     ]
+    workdir = path
+    if platform.system() == "Darwin":
+        cmd.append(path)
+        workdir = None
     if type:
         cmd += [
             "-type",
@@ -1488,7 +1494,7 @@ def bashfind(path, name=None, wholename=None, type=None):
         cmd += ["-name", name]
     if not Path(path).exists():
         return []
-    files = subprocess.check_output(cmd, cwd=path, encoding="utf8").splitlines()
+    files = subprocess.check_output(cmd, cwd=workdir, encoding="utf8").splitlines()
     return list(map(lambda x: Path(path) / x, files))
 
 

--- a/wodoo/tools.py
+++ b/wodoo/tools.py
@@ -1473,7 +1473,7 @@ def _make_sure_module_is_installed(ctx, config, modulename, repo_url):
     )
 
 
-def bashfind(path, name=None, wholename=None, type=None):
+def bashfind(path, name=None, wholename=None, type=None, maxdepth=None):
     import platform
 
     cmd = [
@@ -1484,10 +1484,9 @@ def bashfind(path, name=None, wholename=None, type=None):
         cmd.append(path)
         workdir = None
     if type:
-        cmd += [
-            "-type",
-            type,
-        ]
+        cmd += ["-type", type]
+    if maxdepth:
+        cmd += ["-maxdepth", maxdepth]
     if wholename:
         cmd += ["-wholename", wholename]
     if name:


### PR DESCRIPTION
On MacOS with M1 silicon:
- `uname -m` already returns "arm64"
- `find` always takes the path as the first argument, on Linux this is optional.
This can be fixed by ditching the `cwd` argument on `subprocess.check_output()` and always providing the path.