### PR TITLE
in get_docker_version(), add support for debian specific version suffix

### DIFF
--- a/wodoo/tools.py
+++ b/wodoo/tools.py
@@ -599,6 +599,9 @@ def __safeget(array, index, exception_on_missing, file_options=None):
 def get_docker_version():
     docker = search_env_path("docker")
     version = subprocess.check_output([docker, "--version"], encoding="utf8").strip()
+    # support for stripping debian specific version suffixes
+    version = re.sub("\+dfsg[0-9]*,", "", version)
+    # continue with normal version parsing
     version = list(map(int, version.split(" ")[2].replace(",", "").split(".")))
     return version
 


### PR DESCRIPTION
in debian/devuan current 'docker --version' returns
`Docker version 20.10.24+dfsg1, build 297e128`
which breaks current implementation of wodoo get_docker_version(). This PR adds support for fixing such debian specific version suffixes.